### PR TITLE
support Windows

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,10 @@
 #include "cxxopts.hpp"
 
 std::string getAbsolutePath(std::string path){
-	char * cwdPath;
-	char buff[PATH_MAX + 1];
-	cwdPath = getcwd(buff, PATH_MAX + 1);
+	filesystem::path exePath = filesystem::current_path();
+	
 	if(!ofFilePath::isAbsolute(path)){
-		path = ofFilePath::join(cwdPath, path);
+		path = ofFilePath::join(exePath, path);
 	}
 	return path;
 }


### PR DESCRIPTION
PATH_MAX and getcwd() was not found in Windows 10, vs2017.
app works ok on Windows and probally no problem on maxOS and Linux too.